### PR TITLE
附录B 已验证中文参数 部分中文翻译

### DIFF
--- a/MU5735_NTSB_Recorder_Report_CN/附录B 已验证参数-中文版.md
+++ b/MU5735_NTSB_Recorder_Report_CN/附录B 已验证参数-中文版.md
@@ -1,0 +1,194 @@
+> 译者声明：由DeepSeek翻译，人工抽查，后二次上传给DeepSeek检验。无法保证全部内容精准无误，请自行甄别。中文版文件上传者：TO_GA
+
+本附录描述了已验证并提供给中国民用航空局（CAAC）的参数。表B-1列出了每个参数的名称、单位和说明。此外，表B-2描述了本报告中使用的单位和缩写。
+
+**表B-1. 已验证并提供给CAAC的FDR参数**
+
+| 编号  | 原始英文名                                | 已验证参数名称              | 单位     | 描述              |
+| --- | ------------------------------------ | -------------------- | ------ | --------------- |
+| 1   | Absolute Roll Rate                   | 绝对滚转速率               | 度/秒    | 飞机滚转速率          |
+| 2   | Accel Lat                            | 横向加速度                | g      | 横向加速度           |
+| 3   | Accel Long                           | 纵向加速度                | g      | 纵向加速度           |
+| 4   | Accel Vert                           | 垂直加速度                | g      | 垂直加速度           |
+| 5   | Active Altitude Ref - FCC            | 有效高度基准 - FCC         |        | FCC高度基准         |
+| 6   | Aileron Actuator Pos-L               | 左副翼作动器位置             | 度      | 左副翼作动器位置        |
+| 7   | Aileron Quadrant Pos                 | 副翼操纵扇形盘位置            | 度      | 副翼操纵扇形盘位置       |
+| 8   | Aileron Roll Cmd-L                   | 左副翼滚转指令 - FCC        | 度      | 左FCC副翼滚转指令      |
+| 9   | Aileron-L                            | 左副翼                  | 度      | 左副翼位置           |
+| 10  | Aileron-R                            | 右副翼                  | 度      | 右副翼位置           |
+| 11  | Air Gnd On Gnd                       | 空地传感器 - 地面状态         |        | 空地传感器处于地面状态     |
+| 12  | AIR GROUND - SMYDC-1                 | 空地信号 - SMYDC-1       |        | SMYDC 1 地面状态    |
+| 13  | AIR GROUND - SMYDC-2                 | 空地信号 - SMYDC-2       |        | SMYDC 2 地面状态    |
+| 14  | Air-Ground                           | 空/地                  |        | 空/地状态           |
+| 15  | Airspeed Comp                        | 计算空速                 | 节      | 计算空速            |
+| 16  | Airspeed Max Allowable               | 最大允许空速 - FCC         | 节      | FCC最大允许空速       |
+| 17  | Airspeed Target FCC                  | 目标空速 - FCC           | 节      | FCC计算的目标空速      |
+| 18  | Alt 1 Baro Corr                      | 气压修正高度1              | 英尺     | 气压修正高度1         |
+| 19  | Alt 2 Baro Corr                      | 气压修正高度2              | 英尺     | 气压修正高度2         |
+| 20  | Alt 3 Baro Corr                      | 气压修正高度3              | 英尺     | 气压修正高度3         |
+| 21  | Alt 4 Baro Corr                      | 气压修正高度4              | 英尺     | 气压修正高度4         |
+| 22  | ALT ACQ Engaged - FCC                | 高度截获接通 - FCC         |        | 高度截获自动驾驶模式接通    |
+| 23  | Alt Baro Corr Combine                | 组合气压修正高度             | 英尺     | 组合气压修正高度        |
+| 24  | ALT HOLD Engaged - FCC               | 高度保持接通 - FCC         |        | 高度保持自动驾驶模式接通    |
+| 25  | Altitude Press                       | 压力高度                 | 英尺     | 压力高度            |
+| 26  | Altitude Radio DEU                   | 显示无线电高度 - DEU        | 英尺     | 显示的无线电高度        |
+| 27  | Altitude Radio-1                     | 无线电高度1               | 英尺     | 无线电高度表1         |
+| 28  | Altitude Radio-2                     | 无线电高度2               | 英尺     | 无线电高度表2         |
+| 29  | AP Off - FCC                         | 自动驾驶断开 - FCC         |        | 自动驾驶断开          |
+| 30  | AP-1 Warn                            | 自动驾驶警告1              |        | 自动驾驶警告1         |
+| 31  | AP-2 Warn                            | 自动驾驶警告2              |        | 自动驾驶警告2         |
+| 32  | APU N1                               | APU转速                | %转速    | APU轴转速          |
+| 33  | APU On                               | APU接通                |        | APU运转           |
+| 34  | APU Ready To Load                    | APU可加载               |        | APU准备就绪可加载      |
+| 35  | AT FMC SPD Engaged                   | 自动油门FMC速度接通          |        | 自动油门速度模式接通      |
+| 36  | CMD A - FCC                          | FCC A处于指令            |        | FCC A处于指令状态     |
+| 37  | CMD A Light - FCC                    | FCC A指令灯             |        | FCC A指令灯亮       |
+| 38  | CMD B Light - FCC                    | FCC B指令灯             |        | FCC B指令灯亮       |
+| 39  | Ctrl Col Force Pitch CWS             | 驾驶杆俯仰力（组合）           | 磅      | 组合驾驶杆力          |
+| 40  | Ctrl Col Force Pitch CWS Foreign     | 驾驶杆俯仰力（对侧FCC）        | 磅      | 对侧FCC对应的驾驶杆力    |
+| 41  | Ctrl Col Force Pitch CWS Local       | 驾驶杆俯仰力（指令FCC侧）       | 磅      | 指令FCC侧对应的驾驶杆力   |
+| 42  | Ctrl Col Pos-L                       | 左驾驶杆位置               | 度      | 左驾驶杆位置          |
+| 43  | Ctrl Col Pos-R                       | 右驾驶杆位置               | 度      | 右驾驶杆位置          |
+| 44  | Ctrl Whl Force Roll CWS              | 驾驶盘滚转力               | 磅      | 驾驶盘力            |
+| 45  | Ctrl Whl Pos-L                       | 左驾驶盘位置               | 度      | 左驾驶盘位置          |
+| 46  | Ctrl Whl Pos-R                       | 右驾驶盘位置               | 度      | 右驾驶盘位置          |
+| 47  | Drift Angle -FMC                     | 偏流角 - FMC            | 度      | 计算偏流角           |
+| 48  | Elevator Actuator Pos-L              | 左升降舵作动器位置            | 度      | 左升降舵作动器位置       |
+| 49  | Elevator Pitch Cmd-L                 | 左升降舵俯仰指令 - FCC       | 度      | 左FCC升降舵俯仰指令     |
+| 50  | Elevator-L                           | 左升降舵                 | 度      | 左升降舵位置          |
+| 51  | Elevator-R                           | 右升降舵                 | 度      | 右升降舵位置          |
+| 52  | Eng1 Cutoff SW                       | 左发切断电门               |        | 左发动机切断电门        |
+| 53  | Eng1 EGT                             | 左发EGT                | 摄氏度    | 左发动机排气温度        |
+| 54  | Eng1 Fire                            | 左发火警                 |        | 左发动机火警探测        |
+| 55  | Eng1 FMC N1 Bug Drive                | 左发FMC N1游标驱动         | %转速    | 左发N1游标驱动        |
+| 56  | Eng1 FMC N1 Target                   | 左发FMC N1目标           | %转速    | 左发N1目标值         |
+| 57  | Eng1 FMV Pos                         | 左发FMV位置              | %      | 左发动机燃油计量活门位置    |
+| 58  | Eng1 Fuel Flow                       | 左发燃油流量               | pph    | 左发动机燃油流量        |
+| 59  | Eng1 N1                              | 左发N1                 | %转速    | 左发动机风扇转速        |
+| 60  | Eng1 N1 Cmd                          | 左发N1指令               | %转速    | 左发动机风扇转速指令      |
+| 61  | Eng1 N1 Ref                          | 左发N1参考               | %转速    | 左发动机参考风扇转速      |
+| 62  | Eng1 N1 Tach                         | 左发N1转速表              | %转速    | 左发动机风扇转速表       |
+| 63  | Eng1 N2 Actual                       | 左发N2实际值              | %转速    | 左发动机核心机转速       |
+| 64  | Eng1 N2 Tach                         | 左发N2转速表              | %转速    | 左发动机核心机转速表      |
+| 65  | Eng1 Oil Press                       | 左发滑油压力               | 磅/平方英寸 | 左发动机滑油压力        |
+| 66  | Eng1 Oil Qty                         | 左发滑油量                | 夸脱     | 左发动机滑油量         |
+| 67  | Eng1 Oil Temp                        | 左发滑油温度               | 摄氏度    | 左发动机滑油温度        |
+| 68  | Eng1 TRA                             | 左发TRA                | 度      | 左发动机油门解析器角度     |
+| 69  | Eng2 Cutoff SW                       | 右发切断电门               |        | 右发动机切断电门        |
+| 70  | Eng2 EGT                             | 右发EGT                | 摄氏度    | 右发动机排气温度        |
+| 71  | Eng2 Fire                            | 右发火警                 |        | 右发动机火警探测        |
+| 72  | Eng2 FMC N1 Bug Drive                | 右发FMC N1游标驱动         | %转速    | 右发N1游标驱动        |
+| 73  | Eng2 FMC N1 Target                   | 右发FMC N1目标           | %转速    | 右发N1目标值         |
+| 74  | Eng2 FMV Pos                         | 右发FMV位置              | %      | 右发动机燃油计量活门位置    |
+| 75  | Eng2 Fuel Flow                       | 右发燃油流量               | pph    | 右发动机燃油流量        |
+| 76  | Eng2 N1                              | 右发N1                 | %转速    | 右发动机风扇转速        |
+| 77  | Eng2 N1 Cmd                          | 右发N1指令               | %转速    | 右发动机风扇转速指令      |
+| 78  | Eng2 N1 Ref                          | 右发N1参考               | %转速    | 右发动机参考风扇转速      |
+| 79  | Eng2 N1 Tach                         | 右发N1转速表              | %转速    | 右发动机风扇转速表       |
+| 80  | Eng2 N2 Actual                       | 右发N2实际值              | %转速    | 右发动机核心机转速       |
+| 81  | Eng2 N2 Tach                         | 右发N2转速表              | %转速    | 右发动机核心机转速表      |
+| 82  | Eng2 Oil Press                       | 右发滑油压力               | 磅/平方英寸 | 右发动机滑油压力        |
+| 83  | Eng2 Oil Qty                         | 右发滑油量                | 夸脱     | 右发动机滑油量         |
+| 84  | Eng2 Oil Temp                        | 右发滑油温度               | 摄氏度    | 右发动机滑油温度        |
+| 85  | Eng2 TRA                             | 右发TRA                | 度      | 右发动机油门解析器角度     |
+| 86  | FAC Engage -FCC                      | FAC接通 - FCC          |        | 最终进近航道自动驾驶模式接通  |
+| 87  | FCC In Command of MACH Trim - R      | 右FCC指令马赫配平           |        | 右FCC正在指令马赫配平    |
+| 88  | FCC-L In Command of MACH Trim        | 左FCC指令马赫配平           |        | 左FCC正在指令马赫配平    |
+| 89  | FD-A Switch - FCC                    | FD-A电门 - FCC         |        | 飞行指引仪A电门        |
+| 90  | FD-B Switch - FCC                    | FD-B电门 - FCC         |        | 飞行指引仪B电门        |
+| 91  | Flap Handle Pos                      | 襟翼手柄位置               | 度      | 襟翼手柄位置          |
+| 92  | Flap-L                               | 左襟翼                  | 度      | 左襟翼位置           |
+| 93  | Flap-R                               | 右襟翼                  | 度      | 右襟翼位置           |
+| 94  | FMC Selected Airspeed                | FMC选定空速              | 节      | FMC选定的空速        |
+| 95  | FMC Selected Altitude                | FMC选定高度              | 英尺     | FMC选定的高度        |
+| 96  | FMC Selected Mach                    | FMC选定马赫数             | 马赫     | FMC选定的马赫数       |
+| 97  | FMC Valid                            | FMC有效                |        | FMC数据有效         |
+| 98  | G/S Dev Warn - FCC                   | 下滑道偏差警告 - FCC        |        | 下滑道偏差警告         |
+| 99  | GP Engage - FCC                      | GP接通 - FCC           |        | 下滑道自动驾驶模式接通     |
+| 100 | Ground Spd                           | 地速                   | 节      | 地速              |
+| 101 | Groundspeed FMC                      | FMC地速                | 节      | FMC计算的地速        |
+| 102 | Groundspeed Disp -L                  | 左PFD显示地速             | 节      | 左主飞行显示器显示的地速    |
+| 103 | GS Engaged - FCC                     | GS接通 - FCC           |        | 下滑道自动驾驶模式接通     |
+| 104 | HDG SEL Light - FCC                  | 航向选择灯 - FCC          |        | 航向选择灯亮          |
+| 105 | HDG SELECT - FCC                     | 航向选择接通 - FCC         |        | 航向选择自动驾驶模式接通    |
+| 106 | Heading                              | 航向                   | 度      | 磁航向             |
+| 107 | Heading Selected FCC                 | FCC选定航向              | 度      | FCC选定的航向        |
+| 108 | High Speed Buffet Speed              | 高速抖振速度               | 节      | 高速抖振速度          |
+| 109 | Hyd Oil Press - A                    | A系统液压油压力             | 磅/平方英寸 | A系统液压压力         |
+| 110 | Hyd Oil Press - B                    | B系统液压油压力             | 磅/平方英寸 | B系统液压压力         |
+| 111 | Hyd Oil Qty - A                      | A系统液压油量              | %      | A系统液压油量         |
+| 112 | Hyd Oil Qty - B                      | B系统液压油量              | %      | B系统液压油量         |
+| 113 | Hydraulic Oil Pressure Standby       | 备用液压压力               | 磅/平方英寸 | 备用液压压力          |
+| 114 | Hydraulic System A ELEC              | A系统电动泵               |        | A系统电动泵工作        |
+| 115 | Hydraulic System A Eng 1             | A系统1发驱动泵             |        | A系统1发驱动泵工作      |
+| 116 | Hydraulic System B ELEC              | B系统电动泵               |        | B系统电动泵工作        |
+| 117 | Hydraulic System B Eng 2             | B系统2发驱动泵             |        | B系统2发驱动泵工作      |
+| 118 | Hydraulic System Standby             | 备用液压系统               |        | 备用液压系统接通        |
+| 119 | IAS Display - FCC                    | FCC显示指示空速            |        | 显示的指示空速         |
+| 120 | LNAV Engaged - FCC                   | LNAV接通 - FCC         |        | LNAV自动驾驶模式接通    |
+| 121 | LNAV Light - FCC                     | LNAV灯 - FCC          |        | LNAV灯亮          |
+| 122 | LOC Engaged - FCC                    | LOC接通 - FCC          |        | 航向道自动驾驶模式接通     |
+| 123 | LOCAL LIMITED MASTER FCC-L           | 受限主控左FCC             |        | FCC左主控状态        |
+| 124 | LOCAL LIMITED MASTER FCC-R           | 受限主控右FCC             |        | FCC右主控状态        |
+| 125 | LVL Change Light - FCC               | 飞行高度层改变灯 - FCC       |        | 飞行高度层改变自动驾驶模式激活 |
+| 126 | MACH Trim Servo Brake Status - FCC-L | 马赫配平伺服刹车状态 - FCC-L   |        | 马赫配平伺服刹车状态      |
+| 127 | N1 Light - FCC                       | N1灯 - FCC            |        | N1灯亮            |
+| 128 | N1 Limit Mode Cmd - FCC              | N1限制模式指令 - FCC       |        | N1限制自动油门模式接通    |
+| 129 | Pitch Angle                          | 俯仰角                  | 度      | 飞机俯仰角           |
+| 130 | Roll Angle                           | 滚转角                  | 度      | 飞机滚转角           |
+| 131 | Roll Rate                            | 滚转速率                 | 度/秒    | 飞机滚转速率          |
+| 132 | Rudder                               | 方向舵                  | 度      | 方向舵位置           |
+| 133 | Rudder Ped Pos                       | 方向舵脚蹬位置              | 度      | 方向舵脚蹬位置         |
+| 134 | Rudder Pos- LVDT DEMOD-STBY PCU      | 方向舵位置 - 备用PCU LVDT解调 | 度      | 方向舵备用PCU LVDT位置 |
+| 135 | Rudder Servo Cmd-STBY PCU            | 方向舵伺服指令 - 备用PCU      | 度      | 方向舵备用PCU伺服指令    |
+| 136 | Selected Airspeed FCC                | FCC选定空速              | 节      | FCC选定的空速        |
+| 137 | Selected Altitude FCC                | FCC选定高度              | 英尺     | FCC选定的高度        |
+| 138 | Selected Course Foreign FCC          | 对侧FCC选定航道            | 度      | 对侧FCC选定的航道      |
+| 139 | Selected Course Local FCC            | 本侧FCC选定航道            | 度      | 本侧FCC选定的航道      |
+| 140 | Selected Mach FCC                    | FCC选定马赫数             | 马赫     | FCC选定的马赫数       |
+| 141 | Selected Vertical Speed FCC          | FCC选定垂直速度            | 英尺/分钟  | FCC选定的垂直速度      |
+| 142 | Single Channel - FCC                 | 单通道 - FCC            |        | 自动驾驶单通道工作       |
+| 143 | SPD Light On - FCC                   | SPD灯亮 - FCC          |        | SPD模式灯亮         |
+| 144 | SPEED INTERVENTION ACTIVE - FCC      | 速度干预激活 - FCC         |        | 速度干预激活          |
+| 145 | TOGA Engaged - FCC                   | TOGA接通 - FCC         |        | 自动油门TOGA模式接通    |
+| 146 | Track Angle True FMC                 | FMC真航迹角              | 度      | 真航迹角            |
+| 147 | VISUAL ALTITUDE ALERT - FCC          | 目视高度警告激活 - FCC       |        | 目视高度警告激活        |
+| 148 | VNAV Light On - FCC                  | VNAV灯亮 - FCC         |        | VNAV灯亮          |
+| 149 | VNAV PATH Engaged - FCC              | VNAV航迹接通 - FCC       |        | VNAV航迹自动驾驶模式接通  |
+| 150 | VNAV SPD Engaged - FCC               | VNAV速度接通 - FCC       |        | VNAV速度自动驾驶模式接通  |
+| 151 | Wind Direction True -FMC             | 真风向 - FMC            | 度      | 风向              |
+| 152 | Wind Speed -FMC                      | 风速 - FMC             | 节      | 风速              |
+| 153 | Yaw Rate                             | 偏航速率                 | 度/秒    | 飞机偏航速率          |
+
+**注：** 本飞行数据记录器记录的是基于标准高度表设定29.92英寸汞柱的压力高度。FDR曲线图和表格数据中显示的压力高度未针对事件发生时的本地高度表设定进行修正。
+
+**注：** 表B-1中单位描述栏为空白的参数为离散量。离散量通常是一个1位参数，状态为0或1，且每个参数的每种状态都有其独立定义。
+
+**表B-2. 单位和缩写**
+
+| 单位/缩写 | 描述 |
+|---|---|
+| Alt | 高度 |
+| AP | 自动驾驶 |
+| APU | 辅助动力装置 |
+| AT | 自动油门 |
+| Baro | 气压 |
+| CWS | 驾驶盘/杆操纵 |
+| deg | 度 |
+| degC | 摄氏度 |
+| FCC | 飞行控制计算机 |
+| FMC | 飞行管理计算机 |
+| fpm | 英尺/分钟 |
+| ft | 英尺 |
+| kts | 节 |
+| lbs | 磅 |
+| LVDT | 线性可变差动传感器 |
+| MCP | 方式控制面板 |
+| PCU | 动力控制组件 |
+| PFD | 主飞行显示器 |
+| pph | 磅/小时 |
+| psi | 磅/平方英寸 |
+| qt | 夸脱 |
+| RPM | 转/分钟 |
+| s | 秒 |
+| SMYDC | 失速管理与偏航阻尼计算机 |


### PR DESCRIPTION
在MU5735_NTSB_Recorder_Report_CN文件夹下新增了一个“附录B 已验证参数-中文版.md”文件
内容是“report.pdf”第29-33页的中文翻译
由DeepSeek翻译，人工抽查，后二次上传给DeepSeek检验